### PR TITLE
Use Canonical's ruby-dev-2.5 package, not BrightBox's. git-ignore .bu…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _site/
 .bash_history
 node_modules
 .gemfiles/
+.bundle/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,17 +27,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 ################################################################################
 
 ################################################################################
-# Provides PPA support
-# Package "software-properties-common" provides command "add-apt-repository"
-RUN export DEBIAN_FRONTEND=noninteractive && \
-	apt-get install -y \
-	software-properties-common && \
-# Add Brightbox Ruby 2.x package repository
-	add-apt-repository --yes \
-		ppa:brightbox/ruby-ng
-################################################################################
-
-################################################################################
 # Configure locale for jekyll build
 RUN export DEBIAN_FRONTEND=noninteractive && \
 	apt-get install -y \
@@ -56,7 +45,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 # Install latest software
 # Change the date time stamp if you want to rebuild the image from this point down
 # Useful for Dockerfile development
-ENV SOFTWARE_UPDATED 2018-08-02.1203
+ENV SOFTWARE_UPDATED 2018-08-02.1227
 
 # Install packages
 # Add update && upgrade to this layer in case we're rebuilding from here down
@@ -96,7 +85,7 @@ RUN useradd --create-home --shell /bin/bash buildbot
 
 ################################################################################
 # Dockerfile development only
-ENV CONFIG_UPDATED 2018-08-02.1203
+ENV CONFIG_UPDATED 2018-08-02.1227
 # COPY Gemfile /srv/Gemfile
 ################################################################################
 


### PR DESCRIPTION
- Use Canonical's ruby-dev-2.5 package, not BrightBox's.
  - Why were we using BrightBox's package?
- gitignore .bundle dir